### PR TITLE
HBC-1 Create and configure field_lead

### DIFF
--- a/conf/core.entity_form_display.node.article.default.yml
+++ b/conf/core.entity_form_display.node.article.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.article.body
     - field.field.node.article.comment
     - field.field.node.article.field_image
+    - field.field.node.article.field_lead
     - field.field.node.article.field_tags
     - image.style.thumbnail
     - node.type.article
@@ -23,7 +24,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 2
+    weight: 3
     region: content
     settings:
       rows: 9
@@ -33,27 +34,35 @@ content:
     third_party_settings: {  }
   comment:
     type: comment_default
-    weight: 20
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   field_image:
     type: image_image
-    weight: 1
+    weight: 2
     region: content
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
     third_party_settings: {  }
+  field_lead:
+    type: string_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
   field_tags:
     type: entity_reference_autocomplete_tags
-    weight: 3
+    weight: 4
     region: content
     settings:
       match_operator: CONTAINS
@@ -63,27 +72,27 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 30
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 15
+    weight: 7
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 120
+    weight: 11
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 16
+    weight: 8
     region: content
     settings:
       display_label: true

--- a/conf/core.entity_view_display.node.article.default.yml
+++ b/conf/core.entity_view_display.node.article.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.article.body
     - field.field.node.article.comment
     - field.field.node.article.field_image
+    - field.field.node.article.field_lead
     - field.field.node.article.field_tags
     - image.style.wide
     - node.type.article
@@ -27,7 +28,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 0
+    weight: 2
     region: content
   comment:
     type: comment_default
@@ -36,7 +37,7 @@ content:
       view_mode: default
       pager_id: 0
     third_party_settings: {  }
-    weight: 110
+    weight: 5
     region: content
   field_image:
     type: image
@@ -47,7 +48,14 @@ content:
       image_loading:
         attribute: eager
     third_party_settings: {  }
-    weight: -1
+    weight: 1
+    region: content
+  field_lead:
+    type: basic_string
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
     region: content
   field_tags:
     type: entity_reference_label
@@ -55,11 +63,11 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 10
+    weight: 3
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 100
+    weight: 4
     region: content
 hidden: {  }

--- a/conf/core.entity_view_display.node.article.rss.yml
+++ b/conf/core.entity_view_display.node.article.rss.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.article.body
     - field.field.node.article.comment
     - field.field.node.article.field_image
+    - field.field.node.article.field_lead
     - field.field.node.article.field_tags
     - node.type.article
   module:
@@ -25,4 +26,5 @@ hidden:
   body: true
   comment: true
   field_image: true
+  field_lead: true
   field_tags: true

--- a/conf/core.entity_view_display.node.article.teaser.yml
+++ b/conf/core.entity_view_display.node.article.teaser.yml
@@ -7,12 +7,12 @@ dependencies:
     - field.field.node.article.body
     - field.field.node.article.comment
     - field.field.node.article.field_image
+    - field.field.node.article.field_lead
     - field.field.node.article.field_tags
     - image.style.medium
     - node.type.article
   module:
     - image
-    - text
     - user
 _core:
   default_config_hash: O8PxzfG8DOHHRu6M23kwR6TDPq_MNfYQ10Mp367ICUQ
@@ -21,14 +21,6 @@ targetEntityType: node
 bundle: article
 mode: teaser
 content:
-  body:
-    type: text_summary_or_trimmed
-    label: hidden
-    settings:
-      trim_length: 600
-    third_party_settings: {  }
-    weight: 0
-    region: content
   field_image:
     type: image
     label: hidden
@@ -38,7 +30,14 @@ content:
       image_loading:
         attribute: lazy
     third_party_settings: {  }
-    weight: -1
+    weight: 0
+    region: content
+  field_lead:
+    type: basic_string
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
     region: content
   field_tags:
     type: entity_reference_label
@@ -46,10 +45,13 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 10
+    weight: 2
     region: content
   links:
-    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
     region: content
 hidden:
+  body: true
   comment: true

--- a/conf/field.field.node.article.field_lead.yml
+++ b/conf/field.field.node.article.field_lead.yml
@@ -1,0 +1,19 @@
+uuid: 21dea538-326f-4282-a990-aefd849b14a9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_lead
+    - node.type.article
+id: node.article.field_lead
+field_name: field_lead
+entity_type: node
+bundle: article
+label: Lead
+description: 'The opening paragraph of the article that summarises its main ideas.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/conf/field.storage.node.field_lead.yml
+++ b/conf/field.storage.node.field_lead.yml
@@ -1,0 +1,19 @@
+uuid: 48bfcf4b-425e-4c02-b804-4b6414b52406
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_lead
+field_name: field_lead
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## Related ticket / Customer approval:
- https://docs.google.com/presentation/d/1G3tUbsUbJKg-qL-0SPlfkiU00hUdY0qP-jAR36RhpO4/edit?usp=sharing
  - This would usually be the link to the ticket

## In this PR:
- Created field_lead for content type Article
- Updated form display so the lead input comes after title
- Updated view display:
  - Default: lead comes after title
  - Teaser: lead replaces body

## Testing instructions:
- Checkout branch
- Run `lando start`
- If setting up project for the first time
  - make sure you have a dump.sql inside of root dir
  - run `lando db-import dump.sql`
- Run `lando drush deploy`
  - Ref: [Deploy - Drush](https://www.drush.org/12.x/deploycommand/), TLDR: it combines drush cim and drush cr and some other useful commands.
- Create or edit an Article, add lead text and save
- See that when viewing the Article in full and as teaser, DoD is met
