### PR TITLE
HBC-2 Create path alias audomatically

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "drupal/core-composer-scaffold": "^10.3",
         "drupal/core-project-message": "^10.3",
         "drupal/core-recommended": "^10.3",
+        "drupal/pathauto": "^1.13",
         "drush/drush": "^12.5"
     },
     "conflict": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a6b479b5f1d72493c4ea1025b93076dc",
+    "content-hash": "ed5b9d7e75c32f08493d95d42608a25c",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1465,6 +1465,242 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Core and its dependencies with known-compatible minor versions. Require this project INSTEAD OF drupal/core."
+        },
+        {
+            "name": "drupal/ctools",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/ctools.git",
+                "reference": "4.1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/ctools-4.1.0.zip",
+                "reference": "4.1.0",
+                "shasum": "69f5889cf557df9e55519390e6a95cfa31b67874"
+            },
+            "require": {
+                "drupal/core": "^9.5 || ^10 || ^11"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "4.1.0",
+                    "datestamp": "1718144949",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "branch-alias": {
+                    "dev-8.x-3.x": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Kris Vanderwater (EclipseGc)",
+                    "homepage": "https://www.drupal.org/u/eclipsegc",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Jakob Perry (japerry)",
+                    "homepage": "https://www.drupal.org/u/japerry",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Tim Plunkett (tim.plunkett)",
+                    "homepage": "https://www.drupal.org/u/timplunkett",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "James Gilliland (neclimdul)",
+                    "homepage": "https://www.drupal.org/u/neclimdul",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Daniel Wehner (dawehner)",
+                    "homepage": "https://www.drupal.org/u/dawehner",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "joelpittet",
+                    "homepage": "https://www.drupal.org/user/160302"
+                },
+                {
+                    "name": "merlinofchaos",
+                    "homepage": "https://www.drupal.org/user/26979"
+                },
+                {
+                    "name": "neclimdul",
+                    "homepage": "https://www.drupal.org/user/48673"
+                },
+                {
+                    "name": "sdboyer",
+                    "homepage": "https://www.drupal.org/user/146719"
+                },
+                {
+                    "name": "sun",
+                    "homepage": "https://www.drupal.org/user/54136"
+                },
+                {
+                    "name": "tim.plunkett",
+                    "homepage": "https://www.drupal.org/user/241634"
+                }
+            ],
+            "description": "Provides a number of utility and helper APIs for Drupal developers and site builders.",
+            "homepage": "https://www.drupal.org/project/ctools",
+            "support": {
+                "source": "https://git.drupalcode.org/project/ctools",
+                "issues": "https://www.drupal.org/project/issues/ctools"
+            }
+        },
+        {
+            "name": "drupal/pathauto",
+            "version": "1.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/pathauto.git",
+                "reference": "8.x-1.13"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/pathauto-8.x-1.13.zip",
+                "reference": "8.x-1.13",
+                "shasum": "e64b5a82cf1b8ab48bce400b21ae6fc99c8078fd"
+            },
+            "require": {
+                "drupal/core": "^9.4 || ^10 || ^11",
+                "drupal/ctools": "*",
+                "drupal/token": "*"
+            },
+            "require-dev": {
+                "drupal/forum": "*"
+            },
+            "suggest": {
+                "drupal/redirect": "When installed Pathauto will provide a new \"Update Action\" in case your URLs change. This is the recommended update action and is considered the best practice for SEO and usability."
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.13",
+                    "datestamp": "1722507672",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^9 || ^10"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Berdir",
+                    "homepage": "https://www.drupal.org/user/214652"
+                },
+                {
+                    "name": "Dave Reid",
+                    "homepage": "https://www.drupal.org/user/53892"
+                },
+                {
+                    "name": "Freso",
+                    "homepage": "https://www.drupal.org/user/27504"
+                },
+                {
+                    "name": "greggles",
+                    "homepage": "https://www.drupal.org/user/36762"
+                }
+            ],
+            "description": "Provides a mechanism for modules to automatically generate aliases for the content they manage.",
+            "homepage": "https://www.drupal.org/project/pathauto",
+            "support": {
+                "source": "https://cgit.drupalcode.org/pathauto",
+                "issues": "https://www.drupal.org/project/issues/pathauto",
+                "documentation": "https://www.drupal.org/docs/8/modules/pathauto"
+            }
+        },
+        {
+            "name": "drupal/token",
+            "version": "1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/token.git",
+                "reference": "8.x-1.15"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/token-8.x-1.15.zip",
+                "reference": "8.x-1.15",
+                "shasum": "5916fbccc86458a5f51e71f832ac70ff4c84ebdf"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10 || ^11"
+            },
+            "require-dev": {
+                "drupal/book": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.15",
+                    "datestamp": "1722206211",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": ">=9"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Berdir",
+                    "homepage": "https://www.drupal.org/user/214652"
+                },
+                {
+                    "name": "Dave Reid",
+                    "homepage": "https://www.drupal.org/user/53892"
+                },
+                {
+                    "name": "eaton",
+                    "homepage": "https://www.drupal.org/user/16496"
+                },
+                {
+                    "name": "fago",
+                    "homepage": "https://www.drupal.org/user/16747"
+                },
+                {
+                    "name": "greggles",
+                    "homepage": "https://www.drupal.org/user/36762"
+                },
+                {
+                    "name": "mikeryan",
+                    "homepage": "https://www.drupal.org/user/4420"
+                }
+            ],
+            "description": "Provides a user interface for the Token API, some missing core tokens.",
+            "homepage": "https://www.drupal.org/project/token",
+            "support": {
+                "source": "https://git.drupalcode.org/project/token"
+            }
         },
         {
             "name": "drush/drush",

--- a/conf/core.entity_view_mode.block.token.yml
+++ b/conf/core.entity_view_mode.block.token.yml
@@ -1,0 +1,11 @@
+uuid: 03dd9a20-e0dd-4e35-b7ba-5060e0678220
+langcode: en
+status: true
+dependencies:
+  module:
+    - block
+id: block.token
+label: Token
+description: ''
+targetEntityType: block
+cache: true

--- a/conf/core.entity_view_mode.block_content.token.yml
+++ b/conf/core.entity_view_mode.block_content.token.yml
@@ -1,0 +1,11 @@
+uuid: 66d1f226-a6ee-4d9c-ad83-e7be821f4b70
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.token
+label: Token
+description: ''
+targetEntityType: block_content
+cache: true

--- a/conf/core.entity_view_mode.comment.token.yml
+++ b/conf/core.entity_view_mode.comment.token.yml
@@ -1,0 +1,11 @@
+uuid: 304b6ac4-f52f-474b-b142-f56188847808
+langcode: en
+status: true
+dependencies:
+  module:
+    - comment
+id: comment.token
+label: Token
+description: ''
+targetEntityType: comment
+cache: true

--- a/conf/core.entity_view_mode.contact_message.token.yml
+++ b/conf/core.entity_view_mode.contact_message.token.yml
@@ -1,0 +1,11 @@
+uuid: 619a89c1-7f9d-4f49-bfe2-a7c7f8b6db83
+langcode: en
+status: true
+dependencies:
+  module:
+    - contact
+id: contact_message.token
+label: Token
+description: ''
+targetEntityType: contact_message
+cache: true

--- a/conf/core.entity_view_mode.file.token.yml
+++ b/conf/core.entity_view_mode.file.token.yml
@@ -1,0 +1,11 @@
+uuid: 87212cb6-02aa-4e9d-b1ff-96764462c7d4
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+id: file.token
+label: Token
+description: ''
+targetEntityType: file
+cache: true

--- a/conf/core.entity_view_mode.menu_link_content.token.yml
+++ b/conf/core.entity_view_mode.menu_link_content.token.yml
@@ -1,0 +1,11 @@
+uuid: edff2e88-51d6-45ae-a896-0fa5ebe21134
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_link_content
+id: menu_link_content.token
+label: Token
+description: ''
+targetEntityType: menu_link_content
+cache: true

--- a/conf/core.entity_view_mode.node.token.yml
+++ b/conf/core.entity_view_mode.node.token.yml
@@ -1,0 +1,11 @@
+uuid: ce1055fb-613f-4353-93c5-529656e13d80
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.token
+label: Token
+description: ''
+targetEntityType: node
+cache: true

--- a/conf/core.entity_view_mode.path_alias.token.yml
+++ b/conf/core.entity_view_mode.path_alias.token.yml
@@ -1,0 +1,11 @@
+uuid: 798556ea-c5ff-4b49-9f2a-e99af8dcce10
+langcode: en
+status: true
+dependencies:
+  module:
+    - path_alias
+id: path_alias.token
+label: Token
+description: ''
+targetEntityType: path_alias
+cache: true

--- a/conf/core.entity_view_mode.shortcut.token.yml
+++ b/conf/core.entity_view_mode.shortcut.token.yml
@@ -1,0 +1,11 @@
+uuid: 1a733ff5-4333-4625-ad63-bc2a4ba8c722
+langcode: en
+status: true
+dependencies:
+  module:
+    - shortcut
+id: shortcut.token
+label: Token
+description: ''
+targetEntityType: shortcut
+cache: true

--- a/conf/core.entity_view_mode.taxonomy_term.token.yml
+++ b/conf/core.entity_view_mode.taxonomy_term.token.yml
@@ -1,0 +1,11 @@
+uuid: 1b31adb4-70f0-4eef-b7b6-95e4988340f3
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.token
+label: Token
+description: ''
+targetEntityType: taxonomy_term
+cache: true

--- a/conf/core.entity_view_mode.user.token.yml
+++ b/conf/core.entity_view_mode.user.token.yml
@@ -1,0 +1,11 @@
+uuid: b0513988-80b3-4241-ad11-da69e3799df6
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: user.token
+label: Token
+description: ''
+targetEntityType: user
+cache: true

--- a/conf/core.extension.yml
+++ b/conf/core.extension.yml
@@ -37,10 +37,12 @@ module:
   system: 0
   taxonomy: 0
   text: 0
+  token: 0
   toolbar: 0
   update: 0
   user: 0
   views_ui: 0
+  pathauto: 1
   views: 10
   standard: 1000
 theme:

--- a/conf/pathauto.pattern.articles.yml
+++ b/conf/pathauto.pattern.articles.yml
@@ -1,0 +1,22 @@
+uuid: 825473e2-2bfb-42d5-b16d-0f22830f87a4
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: articles
+label: Articles
+type: 'canonical_entities:node'
+pattern: '/article/[node:title]'
+selection_criteria:
+  330422b2-f675-4781-a581-79480667e4d7:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 330422b2-f675-4781-a581-79480667e4d7
+    context_mapping:
+      node: node
+    bundles:
+      article: article
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/conf/pathauto.pattern.basic_pages.yml
+++ b/conf/pathauto.pattern.basic_pages.yml
@@ -1,0 +1,22 @@
+uuid: 24b40742-c1cd-440f-b231-e6a49ce8213e
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: basic_pages
+label: 'Basic pages'
+type: 'canonical_entities:node'
+pattern: '/[node:title]'
+selection_criteria:
+  217e1434-d22c-4cfe-8c50-df321284963c:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 217e1434-d22c-4cfe-8c50-df321284963c
+    context_mapping:
+      node: node
+    bundles:
+      page: page
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/conf/pathauto.settings.yml
+++ b/conf/pathauto.settings.yml
@@ -1,0 +1,22 @@
+_core:
+  default_config_hash: SwvLp8snyPEExF41CaJJYdPUVomofLqtXvwciHc4cPg
+enabled_entity_types:
+  - user
+punctuation:
+  hyphen: 1
+verbose: false
+separator: '-'
+max_length: 100
+max_component_length: 100
+transliterate: true
+reduce_ascii: false
+case: true
+ignore_words: 'a, an, as, at, before, but, by, for, from, is, in, into, like, of, off, on, onto, per, since, than, the, this, that, to, up, via, with'
+update_action: 2
+safe_tokens:
+  - alias
+  - path
+  - join-path
+  - login-url
+  - url
+  - url-brief

--- a/conf/system.action.pathauto_update_alias_node.yml
+++ b/conf/system.action.pathauto_update_alias_node.yml
@@ -1,0 +1,16 @@
+uuid: bfa104cf-36aa-4494-8b7f-3b829d3c9062
+langcode: en
+status: true
+dependencies:
+  module:
+    - pathauto
+  enforced:
+    module:
+      - node
+_core:
+  default_config_hash: Cr0CsPUSuio4ClP7bOTqHBefJOLtN5KPyKyYj9E4qvQ
+id: pathauto_update_alias_node
+label: 'Update URL alias'
+type: node
+plugin: pathauto_update_alias
+configuration: {  }

--- a/conf/system.action.pathauto_update_alias_user.yml
+++ b/conf/system.action.pathauto_update_alias_user.yml
@@ -1,0 +1,16 @@
+uuid: eabf7e0c-4c67-4916-8666-8e45db93bc62
+langcode: en
+status: true
+dependencies:
+  module:
+    - pathauto
+  enforced:
+    module:
+      - user
+_core:
+  default_config_hash: 6eiNWATGTd3lUEKuxNPNyDRDVMsUlM0HS90_R6JJLUI
+id: pathauto_update_alias_user
+label: 'Update URL alias'
+type: user
+plugin: pathauto_update_alias
+configuration: {  }


### PR DESCRIPTION
## Related ticket / Customer approval:
- https://docs.google.com/presentation/d/1G3tUbsUbJKg-qL-0SPlfkiU00hUdY0qP-jAR36RhpO4/edit?usp=sharing
  - This would usually be the link to the ticket

## In this PR:
- Installed and enabled pathauto
- Configured path alias for content types article and basic_page´

## Testing instructions:
- Checkout branch
- Run `lando start`
- If setting up project for the first time
  - make sure you have a dump.sql inside of root dir
  - run `lando db-import dump.sql`
- Run lando drush deploy
  - Ref: [Deploy - Drush](https://www.drush.org/12.x/deploycommand/), TLDR: it combines drush cim and drush cr and some other useful commands.
- Create an article and a basic_page
- See that the contents you create have the path aliases generated automatically and match the pattern set in the DoD

